### PR TITLE
added listener for page focus to reset filter

### DIFF
--- a/src/screens/PlannerScreen.jsx
+++ b/src/screens/PlannerScreen.jsx
@@ -15,6 +15,15 @@ const PlannerScreen = ({navigation, events, areas, eventsInPlanner}) => {
 
     const toast = useRef(null);
 
+    React.useEffect(() => {
+        const unsubscribe = navigation.addListener('didFocus', () => {
+            setFilter(noFilterName);
+        });
+
+        return () => {unsubscribe.remove()};
+    }, [navigation]);
+    
+
     return (
         <View style={styles.container}>
             <CustomHeader navigation={navigation} title="Planner">


### PR DESCRIPTION
This was to address an issue Mathew Hoy brought up in slack. I decided to just go with option 1 but instead it will just reset the filter on the planner page every time it is focused. 

> Mathew Hoy  10:45 AM
hey team! i was looking through the app just now and it looks great! i noticed though that there are some spots where we could provide a better "error" experience to the end user.
in the attached files you can see what the default view for the planner is ("no events") and what it looks like when you have events added to your schedule.
the "no events" default view of the empty planner could be improved/made more friendly with a message about how to add things to the planner.
we found a related "bug" to this error message. to replicate, try this:
open the planner module and choose the "engineering" filter
go to the schedule module and choose/add a non-engineering event (ie: the "welcome centre" one)
now go back to planner. you'll see a message that says "no events".
the reason it's saying no events (even though we just added one) is because it's stayed on the "engineering" filter we selected earlier.
to avoid confusing people "could swear i just added an event to this thing!", this could be fixed in one of two ways:1) reset the planner filter each time you go into the app 2) at the top of each filter page, say the name of the filter currently enabled (ie: "Engineering filter enabled"). that way the user has an indication about why items are missing from the view and that they could change the filter to see the non-engineering items they've added to the app.
this "issue" might only arise for a few people who explore the app before they get down to using it, but it's better to offer information and better, more helpful error messages than to not suggest how to fix the problem.
hope that helps! i think it looks great so far! :) (edited) 